### PR TITLE
Remove dependency on archived library (`tinymt`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,6 @@ the von Mises distribution is available.
 * [Python 3 random module documentation](http://docs.python.org/3/library/random.html)
 
 
-## Build
-
-The only dependency is [TinyMT Erlang](https://github.com/jj1bdx/tinymt-erlang), which
-is available on [hex.pm](https://hex.pm/packages/tinymt)
-
-    $ mix get.deps
-    $ mix
-
 ## Test
 
     $ mix test

--- a/lib/Random.ex
+++ b/lib/Random.ex
@@ -4,14 +4,9 @@
 # Translated by Guido van Rossum from C source provided by
 # Adrian Baddeley.  Adapted by Raymond Hettinger for use with
 # the Mersenne Twister and os.urandom() core generators.
-#
 # Ported to Elixir by Yuce Tekol.
-#
 # Uniform random number generation code is provided by Kenji Rikitake.
 # https://github.com/jj1bdx/tinymt-erlang/blob/master/src/tinymt32.erl
-#
-# shuffle code is taken straight from Elixir source, and adapted to use
-# TinyMT Erlang.
 
 defmodule Random do
   use Bitwise
@@ -172,18 +167,7 @@ defmodule Random do
 
   Note that for even rather small `size(x)`, the total number of permutations of x is larger than the period of most random number generators; this implies that most permutations of a long sequence can never be generated.
   """
-  def shuffle(enumerable) do
-    randomized = Enum.reduce(enumerable, [], fn x, acc ->
-      [{random(), x}|acc]
-    end)
-    unwrap(:lists.keysort(1, randomized), [])
-  end
-
-  defp unwrap([{_, h} | enumerable], t) do
-    unwrap(enumerable, [h|t])
-  end
-
-  defp unwrap([], t), do: t
+  def shuffle(x), do: Enum.shuffle(x)
 
   @doc """
   Chooses k unique random elements from a population sequence or set.

--- a/lib/Random.ex
+++ b/lib/Random.ex
@@ -5,8 +5,6 @@
 # Adrian Baddeley.  Adapted by Raymond Hettinger for use with
 # the Mersenne Twister and os.urandom() core generators.
 # Ported to Elixir by Yuce Tekol.
-# Uniform random number generation code is provided by Kenji Rikitake.
-# https://github.com/jj1bdx/tinymt-erlang/blob/master/src/tinymt32.erl
 
 defmodule Random do
   use Bitwise
@@ -67,11 +65,12 @@ defmodule Random do
 
       Random.seed(5)
   """
-  def seed({a, b, c}) do
-    :tinymt32.seed(a, b, c)
+  def seed({a, b, c})
+    when is_integer(a) and is_integer(b) and is_integer(c) do
+  :random.seed(a, b, c)
   end
 
-  def seed(a), do: :tinymt32.seed(0, a, 0)
+  def seed(a) when is_integer(a), do: :random.seed(0, a, 0)
 
   @doc """
   Returns a random integer from range `[0, stop)`.
@@ -225,33 +224,11 @@ defmodule Random do
     end
   end
 
-  defp seed0 do
-    {:intstate32, 297425621, 2108342699, 4290625991,
-                  2232209075, 2406486510, 4235788063,
-                  932445695}
-  end
-
-  defp temper_float(r) do
-    :tinymt32.temper(r) * (1.0 / 4294967296.0)
-  end
-
-  defp uniform_s(r0) do
-    r1 = :tinymt32.next_state(r0)
-    {temper_float(r1), r1}
-  end
 
   @doc """
   Return the next random floating point number in the range [0.0, 1.0).
   """
-  def random do
-    r = case :erlang.get(:tinymt32_seed) do
-      :undefined -> seed0()
-      other -> other
-    end
-    {v, r2} = uniform_s(r)
-    :erlang.put(:tinymt32_seed, r2)
-    v
-  end
+  def random, do: :rand.uniform
 
   @doc """
   Return a random floating point number N such that a <= N <= b for a <= b and b <= N <= a for b < a.

--- a/mix.exs
+++ b/mix.exs
@@ -7,8 +7,7 @@ defmodule Random.Mixfile do
       elixir: ">= 1.4.0",
       name: "Random",
       description: description(),
-      package: package(),
-      deps: deps()
+      package: package()
     ]
   end
 
@@ -23,9 +22,5 @@ defmodule Random.Mixfile do
      licenses: ["MIT"],
      links: %{"GitHub" => "https://github.com/yuce/random",
               "Docs" => "http://yuce.me/random/"}]
-  end
-
-  defp deps do
-    [{:tinymt, "~> 0.3.1"}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,1 +1,2 @@
-%{"tinymt": {:hex, :tinymt, "0.3.1", "1f835f3e8840b13daf9d11aa5be8deefcb0765d2bb82d5f52015b63d48eb016f", [:mix, :make], []}}
+%{
+}

--- a/test/random_test.exs
+++ b/test/random_test.exs
@@ -64,16 +64,7 @@ defmodule RandomTest do
     assert(r >= 0 and r < 1)
   end
 
-  test "shuffle" do
-    ls = :lists.seq(1, 20)
-    shuffled_ls = Random.shuffle ls
-    assert(ls != shuffled_ls)
-    s = Enum.into(ls, MapSet.new)
-    assert(MapSet.size(s) == length(ls))
-  end
-
   test "seed" do
     Random.seed(0)
   end
-
 end


### PR DESCRIPTION
### Context
- `tinymt-erlang` is deprecated, and suggests that users _"[m]igrate to the default rand module for OTP 18 and later, because they are maintained and using faster and better algorithms."_ ([link](https://github.com/jj1bdx/tinymt-erlang/blame/08f1763b9c45d9cb0dbf8a37deffcb5ed175a531/README.md#L6))
- closes https://github.com/yuce/random/issues/7